### PR TITLE
fix: remove hard-coded spec filters from fixed_args since they override config file filters

### DIFF
--- a/e2e/workspace/BUILD
+++ b/e2e/workspace/BUILD
@@ -4,4 +4,5 @@ load("@jasmine//jasmine:defs.bzl", "jasmine_test")
 jasmine_test(
     name = "test",
     data = ["test.spec.js"],
+    args = ["*.spec.js"],
 )

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -7,4 +7,6 @@ jasmine_test(
         "lib.spec.js",
         "package.json",
     ],
+    args = ["*.spec.js"],
+    chdir = package_name(),
 )

--- a/jasmine/private/jasmine_test.bzl
+++ b/jasmine/private/jasmine_test.bzl
@@ -14,7 +14,6 @@ _attrs = dicts.add(js_binary_lib.attrs, {
 
 
 def _impl(ctx):
-
     files = js_lib_helpers.gather_files_from_js_providers(
         targets = ctx.attr.data,
         include_transitive_sources = ctx.attr.include_transitive_sources,
@@ -23,11 +22,7 @@ def _impl(ctx):
     )
     files.extend(ctx.files.data)
 
-    fixed_args = [
-        "**/*.spec.*js",
-        "**/*.test.*js"
-    ]
-
+    fixed_args = []
     if ctx.attr.config:
         config_file = ctx.file.config.short_path
         if ctx.attr.chdir:

--- a/jasmine/tests/BUILD.bazel
+++ b/jasmine/tests/BUILD.bazel
@@ -16,15 +16,8 @@ jasmine_test(
 )
 
 jasmine_test(
-    name = "config_no_chdir",
+    name = "config_chdir_package_name",
     data = ["config_file.test.js"],
     config = "config_file.js",
-    chdir = None,
-)
-
-jasmine_test(
-    name = "config_chdir_dot",
-    data = ["config_file.test.js"],
-    config = "config_file.js",
-    chdir = ".",
+    chdir = package_name(),
 )

--- a/jasmine/tests/config_file.js
+++ b/jasmine/tests/config_file.js
@@ -1,6 +1,6 @@
 module.exports = {
     random: false,
     spec_files: [
-        "**/config.test.js"
+        "**/config_file.test.js"
     ],
 };


### PR DESCRIPTION
Having the specs as fixed_args means you can never use spec filters in config files