### PR TITLE
chore: bring in Aspect recommended bazelrc settings

### DIFF
--- a/.aspect/bazelrc/.gitignore
+++ b/.aspect/bazelrc/.gitignore
@@ -1,0 +1,1 @@
+user.bazelrc

--- a/.aspect/bazelrc/BUILD.bazel
+++ b/.aspect/bazelrc/BUILD.bazel
@@ -1,0 +1,14 @@
+"Aspect bazelrc presets; see https://docs.aspect.build/guides/bazelrc"
+
+load("@aspect_bazel_lib//lib:bazelrc_presets.bzl", "write_aspect_bazelrc_presets")
+
+write_aspect_bazelrc_presets(
+    name = "update_aspect_bazelrc_presets",
+    presets = [
+        "convenience",
+        "correctness",
+        "debug",
+        "javascript",
+        "performance",
+    ],
+)

--- a/.aspect/bazelrc/convenience.bazelrc
+++ b/.aspect/bazelrc/convenience.bazelrc
@@ -1,0 +1,28 @@
+# Attempt to build & test every target whose prerequisites were successfully built.
+# Docs: https://bazel.build/docs/user-manual#keep-going
+build --keep_going
+
+# Output test errors to stderr so users don't have to `cat` or open test failure log files when test
+# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# users.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test --test_output=errors
+
+# Show the output files created by builds that requested more than one target. This helps users
+# locate the build outputs in more cases
+# Docs: https://bazel.build/docs/user-manual#show-result
+build --show_result=20
+
+# Bazel picks up host-OS-specific config lines from bazelrc files. For example, if the host OS is
+# Linux and you run bazel build, Bazel picks up lines starting with build:linux. Supported OS
+# identifiers are `linux`, `macos`, `windows`, `freebsd`, and `openbsd`. Enabling this flag is
+# equivalent to using `--config=linux` on Linux, `--config=windows` on Windows, etc.
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
+common --enable_platform_specific_config
+
+# Output a heap dump if an OOM is thrown during a Bazel invocation
+# (including OOMs due to `--experimental_oom_more_eagerly_threshold`).
+# The dump will be written to `<output_base>/<invocation_id>.heapdump.hprof`.
+# You may need to configure CI to capture this artifact and upload for later use.
+# Docs: https://bazel.build/reference/command-line-reference#flag--heap_dump_on_oom
+common --heap_dump_on_oom

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -1,0 +1,62 @@
+# Do not upload locally executed action results to the remote cache.
+# This should be the default for local builds so local builds cannot poison the remote cache.
+# It should be flipped to `--remote_upload_local_results` on CI
+# by using `--bazelrc=.aspect/bazelrc/ci.bazelrc`.
+# Docs: https://bazel.build/reference/command-line-reference#flag--remote_upload_local_results
+build --noremote_upload_local_results
+
+# Don't allow network access for build actions in the sandbox.
+# Ensures that you don't accidentally make non-hermetic actions/tests which depend on remote
+# services.
+# Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
+# Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
+build --sandbox_default_allow_network=false
+
+# Warn if a test's timeout is significantly longer than the test's actual execution time.
+# Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).
+# While a test's timeout should be set such that it is not flaky, a test that has a highly
+# over-generous timeout can hide real problems that crop up unexpectedly.
+# For instance, a test that normally executes in a minute or two should not have a timeout of
+# ETERNAL or LONG as these are much, much too generous.
+# Docs: https://bazel.build/docs/user-manual#test-verbose-timeout-warnings
+test --test_verbose_timeout_warnings
+
+# Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
+# notices when a directory changes, if you have a directory listed in the srcs of some target.
+# Recommended when using
+# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
+# inputs to copy_directory actions.
+# Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
+
+# Allow exclusive tests to run in the sandbox. Fixes a bug where Bazel doesn't enable sandboxing for
+# tests with `tags=["exclusive"]`.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_exclusive_test_sandboxed
+test --incompatible_exclusive_test_sandboxed
+
+# Use a static value for `PATH` and does not inherit `LD_LIBRARY_PATH`. Doesn't let environment
+# variables like `PATH` sneak into the build, which can cause massive cache misses when they change.
+# Use `--action_env=ENV_VARIABLE` if you want to inherit specific environment variables from the
+# client, but note that doing so can prevent cross-user caching if a shared cache is used.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
+build --incompatible_strict_action_env
+
+# Propagate tags from a target declaration to the actions' execution requirements.
+# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
+# get propagated to actions created by the rule.
+# Without this option, you rely on rules authors to manually check the tags you passed
+# and apply relevant ones to the actions they create.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
+fetch --experimental_allow_tags_propagation
+query --experimental_allow_tags_propagation
+
+# Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
+# default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
+# package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the
+# default), it is treated as false if and only if this flag is set. See
+# https://github.com/bazelbuild/bazel/issues/10076.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
+build --incompatible_default_to_explicit_init_py

--- a/.aspect/bazelrc/debug.bazelrc
+++ b/.aspect/bazelrc/debug.bazelrc
@@ -1,0 +1,19 @@
+############################################################
+# Use `bazel test --config=debug` to enable these settings #
+############################################################
+
+# Stream stdout/stderr output from each test in real-time.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test:debug --test_output=streamed
+
+# Run one test at a time.
+# Docs: https://bazel.build/reference/command-line-reference#flag--test_strategy
+test:debug --test_strategy=exclusive
+
+# Prevent long running tests from timing out.
+# Docs: https://bazel.build/docs/user-manual#test-timeout
+test:debug --test_timeout=9999
+
+# Always run tests even if they have cached results.
+# Docs: https://bazel.build/docs/user-manual#cache-test-results
+test:debug --nocache_test_results

--- a/.aspect/bazelrc/javascript.bazelrc
+++ b/.aspect/bazelrc/javascript.bazelrc
@@ -1,0 +1,28 @@
+# Aspect recommended Bazel flags when using Aspect's JavaScript rules: https://github.com/aspect-build/rules_js
+# Docs for Node.js flags: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
+
+# Support for debugging Node.js tests. Use bazel run with `--config=debug` to turn on the NodeJS
+# inspector agent. The node process will break before user code starts and wait for the debugger to
+# connect. Pass the --inspect-brk option to all tests which enables the node inspector agent. See
+# https://nodejs.org/de/docs/guides/debugging-getting-started/#command-line-options for more
+# details.
+# Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
+run:debug -- --node_options=--inspect-brk
+
+# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
+# Windows.
+#
+# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
+# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
+#
+# If you are developing on Windows, you must either run bazel with administrator privileges or
+# enable developer mode. If you do not you may hit this error on Windows:
+#
+#   Bazel needs to create symlinks to build the runfiles tree.
+#   Creating symlinks on Windows requires one of the following:
+#       1. Bazel is run with administrator privileges.
+#       2. The system version is Windows 10 Creators Update (1703) or later
+#          and developer mode is enabled.
+#
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
+build --enable_runfiles

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -1,0 +1,38 @@
+# Speed up all builds by not checking if output files have been modified. Lets you make changes to
+# the output tree without triggering a build for local debugging. For example, you can modify
+# [rules_js](https://github.com/aspect-build/rules_js) 3rd party npm packages in the output tree
+# when local debugging.
+# Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
+build --noexperimental_check_output_files
+fetch --noexperimental_check_output_files
+query --noexperimental_check_output_files
+
+# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
+# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
+# Bazel doesn't write to the local disk cache as it treats as a remote cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
+build --incompatible_remote_results_ignore_disk
+
+# Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
+# Save time on Sandbox creation and deletion when many of the same kind of action run during the
+# build.
+# No longer experimental in Bazel 6: https://github.com/bazelbuild/bazel/commit/c1a95501a5611878e5cc43a3cc531f2b9e47835b
+# Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
+build --experimental_reuse_sandbox_directories
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles
+
+# Some actions are always IO-intensive but require little compute. It's wasteful to put the output
+# in the remote cache, it just saturates the network and fills the cache storage causing earlier
+# evictions. It's also not worth sending them for remote execution.
+# For actions like PackageTar it's usually faster to just re-run the work locally every time.
+# You'll have to look at an execution log to figure out what other action mnemonics you care about.
+# In some cases you may need to patch rulesets to add a mnemonic to actions that don't have one.
+# https://bazel.build/reference/command-line-reference#flag--modify_execution_info
+build --modify_execution_info=PackageTar=+no-remote

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,13 +1,17 @@
 # Bazel settings that apply to this repository.
-# Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
+# Import Aspect bazelrc presets
+# import %workspace%/.aspect/bazelrc/convenience.bazelrc
+# import %workspace%/.aspect/bazelrc/correctness.bazelrc
+# import %workspace%/.aspect/bazelrc/performance.bazelrc
+# import %workspace%/.aspect/bazelrc/debug.bazelrc
+# import %workspace%/.aspect/bazelrc/javascript.bazelrc
+build --enable_runfiles
+### PROJECT SPECIFIC OPTIONS ###
 
-# Load any settings specific to the current user.
-# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
-# This needs to be last statement in this
-# config, as the user configuration should be able to overwrite flags from this file.
-# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
-# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
-# rather than user.bazelrc as suggested in the Bazel docs)
-try-import %workspace%/.bazelrc.user
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/.aspect/bazelrc/user.bazelrc

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.0.0
+6.1.0
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/Enable-DeveloperMode.ps1
+++ b/.github/workflows/Enable-DeveloperMode.ps1
@@ -1,0 +1,13 @@
+################################################################################
+##  File:  Enable-DeveloperMode.ps1
+##  Desc:  Enables Developer Mode by toggling registry setting. Developer Mode is required to enable certain tools (e.g. WinAppDriver). 
+################################################################################
+
+# Create AppModelUnlock if it doesn't exist, required for enabling Developer Mode
+$RegistryKeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"
+if (-not(Test-Path -Path $RegistryKeyPath)) {
+    New-Item -Path $RegistryKeyPath -ItemType Directory -Force
+}
+
+# Add registry value to enable Developer Mode
+New-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,128 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # matrix-prep-* steps generate JSON used to create a dynamic actions matrix.
+  # Insanely complex for how simple this requirement is inspired from
+  # https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
+
+  matrix-prep-os:
+    # Prepares the 'os' axis of the test matrix, to reduce costs since GitHub hosted runners cost more on some platforms.
+    # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+    runs-on: ubuntu-latest
+    steps:
+      - id: linux
+        run: echo "os=ubuntu-latest" >> $GITHUB_OUTPUT
+      - id: windows
+        run: echo "os=windows-2022" >> $GITHUB_OUTPUT
+        # Only run on main branch (or PR branches that contain 'windows') to minimize Windows minutes (billed at 2X)
+        if: github.ref == 'refs/heads/main' || contains(github.head_ref, 'windows')
+      - id: macos
+        run: echo "os=macos-latest" >> $GITHUB_OUTPUT
+        # Only run on main branch (or PR branches that contain 'macos') to minimize macOS minutes (billed at 10X)
+        if: github.ref == 'refs/heads/main' || contains(github.head_ref, 'macos')
+    outputs:
+      # Will look like ["ubuntu-latest", "windows-2022", "macos-latest"]
+      os: ${{ toJSON(steps.*.outputs.os) }}
+
+  matrix-prep-bazelversion:
+    # Prepares the 'bazelversion' axis of the test matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: bazel_from_bazelversion
+        run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
+      - id: bazel_5
+        run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
+    outputs:
+      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
+
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
-    with:
-      folders: '[".", "e2e/jasmine_test", "e2e/smoke"]'
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    needs:
+      - matrix-prep-bazelversion
+      - matrix-prep-os
+
+    # Run bazel test in each workspace with each version of Bazel supported
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.matrix-prep-os.outputs.os) }}
+        bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
+        folder: [".", "e2e/jasmine_test", "e2e/smoke"]
+        bzlmodEnabled: [true, false]
+        exclude:
+          # Don't test bzlmod with Bazel 5 (not supported)
+          - bazelversion: 5.3.2
+            bzlmodEnabled: true
+          # Don't test macos with Bazel 5 to minimize macOS minutes (billed at 10X)
+          # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+          - os: macos-latest
+            bazelversion: 5.3.2
+          # Don't test Windows with Bazel 5 to minimize Windows minutes (billed at 2X)
+          # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+          - os: windows-2022
+            bazelversion: 5.3.2
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Cache build and external artifacts so that the next ci build is incremental.
+      # Because github action caches cannot be updated after a build, we need to
+      # store the contents of each build in a unique cache key, then fall back to loading
+      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
+      # the prefix to load the most recent cache for the branch on a cache miss. You
+      # should customize the contents of hashFiles to capture any bazel input sources,
+      # although this doesn't need to be perfect. If none of the input sources change
+      # then a cache hit will load an existing cache and bazel won't have to do any work.
+      # In the case of a cache miss, you want the fallback cache to contain most of the
+      # previously built artifacts to minimize build time. The more precise you are with
+      # hashFiles sources the less work bazel will have to do.
+      - name: Mount bazel caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
+
+      - name: Configure Bazel version
+        working-directory: ${{ matrix.folder }}
+        run: echo "${{ matrix.bazelversion }}" > .bazelversion
+
+      - name: Check for test.sh
+        # Checks for the existence of test.sh in the folder. Downstream steps can use
+        # steps.has_test_sh.outputs.files_exists as a conditional.
+        id: has_test_sh
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "${{ matrix.folder }}/test.sh"
+
+      - name: Set bzlmod flag
+        # Store the --enable_bzlmod flag that we add to the test command below
+        # only when we're running bzlmod in our test matrix.
+        id: set_bzlmod_flag
+        if: matrix.bzlmodEnabled
+        run: echo "bzlmod_flag=--enable_bzlmod" >> $GITHUB_OUTPUT
+
+      - name: bazel test //...
+        env:
+          # Bazelisk will download bazel to here, ensure it is cached between runs.
+          XDG_CACHE_HOME: ~/.cache/bazel-repo
+        working-directory: ${{ matrix.folder }}
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...
+
+      - name: ./test.sh
+        # Run if there is a test.sh file in the folder
+        # Don't run integration tests on Windows since they are bash scripts and Windows runs Powershell
+        if: steps.has_test_sh.outputs.files_exists == 'true' && ! startsWith(matrix.os, 'windows')
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        # Run the script potentially setting BZLMOD_FLAG=--enable_bzlmod. All test.sh
+        # scripts that run bazel directly should make use of this variable.
+        run: BZLMOD_FLAG=${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} ./test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bazel-*
-.bazelrc.user
 .idea/
 .ijwb/
 node_modules

--- a/e2e/jasmine_test/.aspect/bazelrc/.gitignore
+++ b/e2e/jasmine_test/.aspect/bazelrc/.gitignore
@@ -1,0 +1,1 @@
+user.bazelrc

--- a/e2e/jasmine_test/.aspect/bazelrc/BUILD.bazel
+++ b/e2e/jasmine_test/.aspect/bazelrc/BUILD.bazel
@@ -1,0 +1,14 @@
+"Aspect bazelrc presets; see https://docs.aspect.build/guides/bazelrc"
+
+load("@aspect_bazel_lib//lib:bazelrc_presets.bzl", "write_aspect_bazelrc_presets")
+
+write_aspect_bazelrc_presets(
+    name = "update_aspect_bazelrc_presets",
+    presets = [
+        "convenience",
+        "correctness",
+        "debug",
+        "javascript",
+        "performance",
+    ],
+)

--- a/e2e/jasmine_test/.aspect/bazelrc/convenience.bazelrc
+++ b/e2e/jasmine_test/.aspect/bazelrc/convenience.bazelrc
@@ -1,0 +1,28 @@
+# Attempt to build & test every target whose prerequisites were successfully built.
+# Docs: https://bazel.build/docs/user-manual#keep-going
+build --keep_going
+
+# Output test errors to stderr so users don't have to `cat` or open test failure log files when test
+# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# users.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test --test_output=errors
+
+# Show the output files created by builds that requested more than one target. This helps users
+# locate the build outputs in more cases
+# Docs: https://bazel.build/docs/user-manual#show-result
+build --show_result=20
+
+# Bazel picks up host-OS-specific config lines from bazelrc files. For example, if the host OS is
+# Linux and you run bazel build, Bazel picks up lines starting with build:linux. Supported OS
+# identifiers are `linux`, `macos`, `windows`, `freebsd`, and `openbsd`. Enabling this flag is
+# equivalent to using `--config=linux` on Linux, `--config=windows` on Windows, etc.
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
+common --enable_platform_specific_config
+
+# Output a heap dump if an OOM is thrown during a Bazel invocation
+# (including OOMs due to `--experimental_oom_more_eagerly_threshold`).
+# The dump will be written to `<output_base>/<invocation_id>.heapdump.hprof`.
+# You may need to configure CI to capture this artifact and upload for later use.
+# Docs: https://bazel.build/reference/command-line-reference#flag--heap_dump_on_oom
+common --heap_dump_on_oom

--- a/e2e/jasmine_test/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/jasmine_test/.aspect/bazelrc/correctness.bazelrc
@@ -1,0 +1,62 @@
+# Do not upload locally executed action results to the remote cache.
+# This should be the default for local builds so local builds cannot poison the remote cache.
+# It should be flipped to `--remote_upload_local_results` on CI
+# by using `--bazelrc=.aspect/bazelrc/ci.bazelrc`.
+# Docs: https://bazel.build/reference/command-line-reference#flag--remote_upload_local_results
+build --noremote_upload_local_results
+
+# Don't allow network access for build actions in the sandbox.
+# Ensures that you don't accidentally make non-hermetic actions/tests which depend on remote
+# services.
+# Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
+# Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
+build --sandbox_default_allow_network=false
+
+# Warn if a test's timeout is significantly longer than the test's actual execution time.
+# Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).
+# While a test's timeout should be set such that it is not flaky, a test that has a highly
+# over-generous timeout can hide real problems that crop up unexpectedly.
+# For instance, a test that normally executes in a minute or two should not have a timeout of
+# ETERNAL or LONG as these are much, much too generous.
+# Docs: https://bazel.build/docs/user-manual#test-verbose-timeout-warnings
+test --test_verbose_timeout_warnings
+
+# Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
+# notices when a directory changes, if you have a directory listed in the srcs of some target.
+# Recommended when using
+# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
+# inputs to copy_directory actions.
+# Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
+
+# Allow exclusive tests to run in the sandbox. Fixes a bug where Bazel doesn't enable sandboxing for
+# tests with `tags=["exclusive"]`.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_exclusive_test_sandboxed
+test --incompatible_exclusive_test_sandboxed
+
+# Use a static value for `PATH` and does not inherit `LD_LIBRARY_PATH`. Doesn't let environment
+# variables like `PATH` sneak into the build, which can cause massive cache misses when they change.
+# Use `--action_env=ENV_VARIABLE` if you want to inherit specific environment variables from the
+# client, but note that doing so can prevent cross-user caching if a shared cache is used.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
+build --incompatible_strict_action_env
+
+# Propagate tags from a target declaration to the actions' execution requirements.
+# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
+# get propagated to actions created by the rule.
+# Without this option, you rely on rules authors to manually check the tags you passed
+# and apply relevant ones to the actions they create.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
+fetch --experimental_allow_tags_propagation
+query --experimental_allow_tags_propagation
+
+# Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
+# default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
+# package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the
+# default), it is treated as false if and only if this flag is set. See
+# https://github.com/bazelbuild/bazel/issues/10076.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
+build --incompatible_default_to_explicit_init_py

--- a/e2e/jasmine_test/.aspect/bazelrc/debug.bazelrc
+++ b/e2e/jasmine_test/.aspect/bazelrc/debug.bazelrc
@@ -1,0 +1,19 @@
+############################################################
+# Use `bazel test --config=debug` to enable these settings #
+############################################################
+
+# Stream stdout/stderr output from each test in real-time.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test:debug --test_output=streamed
+
+# Run one test at a time.
+# Docs: https://bazel.build/reference/command-line-reference#flag--test_strategy
+test:debug --test_strategy=exclusive
+
+# Prevent long running tests from timing out.
+# Docs: https://bazel.build/docs/user-manual#test-timeout
+test:debug --test_timeout=9999
+
+# Always run tests even if they have cached results.
+# Docs: https://bazel.build/docs/user-manual#cache-test-results
+test:debug --nocache_test_results

--- a/e2e/jasmine_test/.aspect/bazelrc/javascript.bazelrc
+++ b/e2e/jasmine_test/.aspect/bazelrc/javascript.bazelrc
@@ -1,0 +1,28 @@
+# Aspect recommended Bazel flags when using Aspect's JavaScript rules: https://github.com/aspect-build/rules_js
+# Docs for Node.js flags: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
+
+# Support for debugging Node.js tests. Use bazel run with `--config=debug` to turn on the NodeJS
+# inspector agent. The node process will break before user code starts and wait for the debugger to
+# connect. Pass the --inspect-brk option to all tests which enables the node inspector agent. See
+# https://nodejs.org/de/docs/guides/debugging-getting-started/#command-line-options for more
+# details.
+# Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
+run:debug -- --node_options=--inspect-brk
+
+# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
+# Windows.
+#
+# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
+# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
+#
+# If you are developing on Windows, you must either run bazel with administrator privileges or
+# enable developer mode. If you do not you may hit this error on Windows:
+#
+#   Bazel needs to create symlinks to build the runfiles tree.
+#   Creating symlinks on Windows requires one of the following:
+#       1. Bazel is run with administrator privileges.
+#       2. The system version is Windows 10 Creators Update (1703) or later
+#          and developer mode is enabled.
+#
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
+build --enable_runfiles

--- a/e2e/jasmine_test/.aspect/bazelrc/performance.bazelrc
+++ b/e2e/jasmine_test/.aspect/bazelrc/performance.bazelrc
@@ -1,0 +1,38 @@
+# Speed up all builds by not checking if output files have been modified. Lets you make changes to
+# the output tree without triggering a build for local debugging. For example, you can modify
+# [rules_js](https://github.com/aspect-build/rules_js) 3rd party npm packages in the output tree
+# when local debugging.
+# Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
+build --noexperimental_check_output_files
+fetch --noexperimental_check_output_files
+query --noexperimental_check_output_files
+
+# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
+# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
+# Bazel doesn't write to the local disk cache as it treats as a remote cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
+build --incompatible_remote_results_ignore_disk
+
+# Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
+# Save time on Sandbox creation and deletion when many of the same kind of action run during the
+# build.
+# No longer experimental in Bazel 6: https://github.com/bazelbuild/bazel/commit/c1a95501a5611878e5cc43a3cc531f2b9e47835b
+# Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
+build --experimental_reuse_sandbox_directories
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles
+
+# Some actions are always IO-intensive but require little compute. It's wasteful to put the output
+# in the remote cache, it just saturates the network and fills the cache storage causing earlier
+# evictions. It's also not worth sending them for remote execution.
+# For actions like PackageTar it's usually faster to just re-run the work locally every time.
+# You'll have to look at an execution log to figure out what other action mnemonics you care about.
+# In some cases you may need to patch rulesets to add a mnemonic to actions that don't have one.
+# https://bazel.build/reference/command-line-reference#flag--modify_execution_info
+build --modify_execution_info=PackageTar=+no-remote

--- a/e2e/jasmine_test/.bazelrc
+++ b/e2e/jasmine_test/.bazelrc
@@ -1,0 +1,18 @@
+# Bazel settings that apply to this repository.
+# Settings that apply only to CI are in .github/workflows/ci.bazelrc
+
+# Import Aspect bazelrc presets
+# import %workspace%/.aspect/bazelrc/convenience.bazelrc
+# import %workspace%/.aspect/bazelrc/correctness.bazelrc
+# import %workspace%/.aspect/bazelrc/performance.bazelrc
+# import %workspace%/.aspect/bazelrc/debug.bazelrc
+# import %workspace%/.aspect/bazelrc/javascript.bazelrc
+build --enable_runfiles
+
+### PROJECT SPECIFIC OPTIONS ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/.aspect/bazelrc/user.bazelrc

--- a/e2e/smoke/.aspect/bazelrc/.gitignore
+++ b/e2e/smoke/.aspect/bazelrc/.gitignore
@@ -1,0 +1,1 @@
+user.bazelrc

--- a/e2e/smoke/.aspect/bazelrc/BUILD.bazel
+++ b/e2e/smoke/.aspect/bazelrc/BUILD.bazel
@@ -1,0 +1,14 @@
+"Aspect bazelrc presets; see https://docs.aspect.build/guides/bazelrc"
+
+load("@aspect_bazel_lib//lib:bazelrc_presets.bzl", "write_aspect_bazelrc_presets")
+
+write_aspect_bazelrc_presets(
+    name = "update_aspect_bazelrc_presets",
+    presets = [
+        "convenience",
+        "correctness",
+        "debug",
+        "javascript",
+        "performance",
+    ],
+)

--- a/e2e/smoke/.aspect/bazelrc/convenience.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/convenience.bazelrc
@@ -1,0 +1,28 @@
+# Attempt to build & test every target whose prerequisites were successfully built.
+# Docs: https://bazel.build/docs/user-manual#keep-going
+build --keep_going
+
+# Output test errors to stderr so users don't have to `cat` or open test failure log files when test
+# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# users.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test --test_output=errors
+
+# Show the output files created by builds that requested more than one target. This helps users
+# locate the build outputs in more cases
+# Docs: https://bazel.build/docs/user-manual#show-result
+build --show_result=20
+
+# Bazel picks up host-OS-specific config lines from bazelrc files. For example, if the host OS is
+# Linux and you run bazel build, Bazel picks up lines starting with build:linux. Supported OS
+# identifiers are `linux`, `macos`, `windows`, `freebsd`, and `openbsd`. Enabling this flag is
+# equivalent to using `--config=linux` on Linux, `--config=windows` on Windows, etc.
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
+common --enable_platform_specific_config
+
+# Output a heap dump if an OOM is thrown during a Bazel invocation
+# (including OOMs due to `--experimental_oom_more_eagerly_threshold`).
+# The dump will be written to `<output_base>/<invocation_id>.heapdump.hprof`.
+# You may need to configure CI to capture this artifact and upload for later use.
+# Docs: https://bazel.build/reference/command-line-reference#flag--heap_dump_on_oom
+common --heap_dump_on_oom

--- a/e2e/smoke/.aspect/bazelrc/correctness.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/correctness.bazelrc
@@ -1,0 +1,62 @@
+# Do not upload locally executed action results to the remote cache.
+# This should be the default for local builds so local builds cannot poison the remote cache.
+# It should be flipped to `--remote_upload_local_results` on CI
+# by using `--bazelrc=.aspect/bazelrc/ci.bazelrc`.
+# Docs: https://bazel.build/reference/command-line-reference#flag--remote_upload_local_results
+build --noremote_upload_local_results
+
+# Don't allow network access for build actions in the sandbox.
+# Ensures that you don't accidentally make non-hermetic actions/tests which depend on remote
+# services.
+# Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
+# Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
+build --sandbox_default_allow_network=false
+
+# Warn if a test's timeout is significantly longer than the test's actual execution time.
+# Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).
+# While a test's timeout should be set such that it is not flaky, a test that has a highly
+# over-generous timeout can hide real problems that crop up unexpectedly.
+# For instance, a test that normally executes in a minute or two should not have a timeout of
+# ETERNAL or LONG as these are much, much too generous.
+# Docs: https://bazel.build/docs/user-manual#test-verbose-timeout-warnings
+test --test_verbose_timeout_warnings
+
+# Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
+# notices when a directory changes, if you have a directory listed in the srcs of some target.
+# Recommended when using
+# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
+# inputs to copy_directory actions.
+# Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
+
+# Allow exclusive tests to run in the sandbox. Fixes a bug where Bazel doesn't enable sandboxing for
+# tests with `tags=["exclusive"]`.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_exclusive_test_sandboxed
+test --incompatible_exclusive_test_sandboxed
+
+# Use a static value for `PATH` and does not inherit `LD_LIBRARY_PATH`. Doesn't let environment
+# variables like `PATH` sneak into the build, which can cause massive cache misses when they change.
+# Use `--action_env=ENV_VARIABLE` if you want to inherit specific environment variables from the
+# client, but note that doing so can prevent cross-user caching if a shared cache is used.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
+build --incompatible_strict_action_env
+
+# Propagate tags from a target declaration to the actions' execution requirements.
+# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
+# get propagated to actions created by the rule.
+# Without this option, you rely on rules authors to manually check the tags you passed
+# and apply relevant ones to the actions they create.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
+fetch --experimental_allow_tags_propagation
+query --experimental_allow_tags_propagation
+
+# Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
+# default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
+# package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the
+# default), it is treated as false if and only if this flag is set. See
+# https://github.com/bazelbuild/bazel/issues/10076.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
+build --incompatible_default_to_explicit_init_py

--- a/e2e/smoke/.aspect/bazelrc/debug.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/debug.bazelrc
@@ -1,0 +1,19 @@
+############################################################
+# Use `bazel test --config=debug` to enable these settings #
+############################################################
+
+# Stream stdout/stderr output from each test in real-time.
+# Docs: https://bazel.build/docs/user-manual#test-output
+test:debug --test_output=streamed
+
+# Run one test at a time.
+# Docs: https://bazel.build/reference/command-line-reference#flag--test_strategy
+test:debug --test_strategy=exclusive
+
+# Prevent long running tests from timing out.
+# Docs: https://bazel.build/docs/user-manual#test-timeout
+test:debug --test_timeout=9999
+
+# Always run tests even if they have cached results.
+# Docs: https://bazel.build/docs/user-manual#cache-test-results
+test:debug --nocache_test_results

--- a/e2e/smoke/.aspect/bazelrc/javascript.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/javascript.bazelrc
@@ -1,0 +1,28 @@
+# Aspect recommended Bazel flags when using Aspect's JavaScript rules: https://github.com/aspect-build/rules_js
+# Docs for Node.js flags: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
+
+# Support for debugging Node.js tests. Use bazel run with `--config=debug` to turn on the NodeJS
+# inspector agent. The node process will break before user code starts and wait for the debugger to
+# connect. Pass the --inspect-brk option to all tests which enables the node inspector agent. See
+# https://nodejs.org/de/docs/guides/debugging-getting-started/#command-line-options for more
+# details.
+# Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
+run:debug -- --node_options=--inspect-brk
+
+# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
+# Windows.
+#
+# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
+# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
+#
+# If you are developing on Windows, you must either run bazel with administrator privileges or
+# enable developer mode. If you do not you may hit this error on Windows:
+#
+#   Bazel needs to create symlinks to build the runfiles tree.
+#   Creating symlinks on Windows requires one of the following:
+#       1. Bazel is run with administrator privileges.
+#       2. The system version is Windows 10 Creators Update (1703) or later
+#          and developer mode is enabled.
+#
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
+build --enable_runfiles

--- a/e2e/smoke/.aspect/bazelrc/performance.bazelrc
+++ b/e2e/smoke/.aspect/bazelrc/performance.bazelrc
@@ -1,0 +1,38 @@
+# Speed up all builds by not checking if output files have been modified. Lets you make changes to
+# the output tree without triggering a build for local debugging. For example, you can modify
+# [rules_js](https://github.com/aspect-build/rules_js) 3rd party npm packages in the output tree
+# when local debugging.
+# Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
+build --noexperimental_check_output_files
+fetch --noexperimental_check_output_files
+query --noexperimental_check_output_files
+
+# Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
+# If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
+# Bazel doesn't write to the local disk cache as it treats as a remote cache.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
+build --incompatible_remote_results_ignore_disk
+
+# Directories used by sandboxed non-worker execution may be reused to avoid unnecessary setup costs.
+# Save time on Sandbox creation and deletion when many of the same kind of action run during the
+# build.
+# No longer experimental in Bazel 6: https://github.com/bazelbuild/bazel/commit/c1a95501a5611878e5cc43a3cc531f2b9e47835b
+# Docs: https://bazel.build/reference/command-line-reference#flag--reuse_sandbox_directories
+build --experimental_reuse_sandbox_directories
+
+# Do not build runfiles symlink forests for external repositories under
+# `.runfiles/wsname/external/repo` (in addition to `.runfiles/repo`). This reduces runfiles &
+# sandbox creation times & prevents accidentally depending on this feature which may flip to off by
+# default in the future. Note, some rules may fail under this flag, please file issues with the rule
+# author.
+# Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles
+
+# Some actions are always IO-intensive but require little compute. It's wasteful to put the output
+# in the remote cache, it just saturates the network and fills the cache storage causing earlier
+# evictions. It's also not worth sending them for remote execution.
+# For actions like PackageTar it's usually faster to just re-run the work locally every time.
+# You'll have to look at an execution log to figure out what other action mnemonics you care about.
+# In some cases you may need to patch rulesets to add a mnemonic to actions that don't have one.
+# https://bazel.build/reference/command-line-reference#flag--modify_execution_info
+build --modify_execution_info=PackageTar=+no-remote

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,6 +1,18 @@
-#   rules_js needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
+# Bazel settings that apply to this repository.
+# Settings that apply only to CI are in .github/workflows/ci.bazelrc
+
+# Import Aspect bazelrc presets
+# import %workspace%/.aspect/bazelrc/convenience.bazelrc
+# import %workspace%/.aspect/bazelrc/correctness.bazelrc
+# import %workspace%/.aspect/bazelrc/performance.bazelrc
+# import %workspace%/.aspect/bazelrc/debug.bazelrc
+# import %workspace%/.aspect/bazelrc/javascript.bazelrc
 build --enable_runfiles
+
+### PROJECT SPECIFIC OPTIONS ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/.aspect/bazelrc/user.bazelrc

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,4 +1,5 @@
 "Bazel dependencies"
+bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
 bazel_dep(name = "aspect_rules_jasmine", dev_dependency = True, version = "0.0.0")
 bazel_dep(name = "aspect_rules_js", version = "1.23.2")
 


### PR DESCRIPTION
# Description

Also areens up Windows CI which requires --enable_runfiles.

Intentionally _not_ bringing in bazel6 and bazel5 recommended settings since the patterns for flipping between the rc files on the CI bazel version matrix are not great yet and not covered by `bazel-contrib/.github/.github/workflows/bazel.yaml@v2`

# Type of change

- [x] Chore (any other change that doesn't affect source or test files)

# Test plan

- [x] Covered by existing tests cases
