### PR TITLE
fix: release used wrong reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v2
     with:
       release_files: rules_jasmine-*.tar.gz


### PR DESCRIPTION
Same as the fix in rules_cypress.

# Type of change

- [x] Bug fix (change which fixes an issue)

# Test plan

Cut a release