### PR TITLE
feat: update to rules_js 1.27.0 and pickup fixed_args feature

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,8 +6,8 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
-bazel_dep(name = "aspect_rules_js", version = "1.24.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
+bazel_dep(name = "aspect_rules_js", version = "1.27.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,6 +1,6 @@
 "Bazel dependencies"
 bazel_dep(name = "aspect_rules_jasmine", dev_dependency = True, version = "0.0.0")
-bazel_dep(name = "aspect_rules_js", version = "1.24.1")
+bazel_dep(name = "aspect_rules_js", version = "1.27.0")
 
 local_path_override(
     module_name = "aspect_rules_jasmine",

--- a/jasmine/dependencies.bzl
+++ b/jasmine/dependencies.bzl
@@ -15,16 +15,16 @@ def rules_jasmine_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "ee95bbc80f9ca219b93a8cc49fa19a2d4aa8649ddc9024f46abcdd33935753ca",
-        strip_prefix = "bazel-lib-1.29.2",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.29.2/bazel-lib-v1.29.2.tar.gz",
+        sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
+        strip_prefix = "bazel-lib-1.32.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "aea8d12bdc4b40127e57fb3da5b61cbb17e969e7786471a71cbff0808c600bcb",
-        strip_prefix = "rules_js-1.24.1",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.24.1/rules_js-v1.24.1.tar.gz",
+        sha256 = "d8827db3c34fe47607a0668e86524fd85d5bd74f2bfca93046d07f890b5ad4df",
+        strip_prefix = "rules_js-1.27.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.27.0/rules_js-v1.27.0.tar.gz",
     )
 
     http_archive(

--- a/jasmine/private/jasmine_test.bzl
+++ b/jasmine/private/jasmine_test.bzl
@@ -15,7 +15,12 @@ _attrs = dicts.add(js_binary_lib.attrs, {
 
 def _impl(ctx):
     files = ctx.files.data[:]
+
     fixed_args = []
+
+    # TODO(2.0): we can assume fixed_args exists on attr for the 2.0 major release (it comes from rules_js 1.27.0)
+    if hasattr(ctx.attr, "fixed_args"):
+        fixed_args.extend(ctx.attr.fixed_args)
 
     if ctx.attr.junit_reporter:
         files.append(ctx.file.junit_reporter)

--- a/jasmine/tests/fixed_args/BUILD.bazel
+++ b/jasmine/tests/fixed_args/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//jasmine:defs.bzl", "jasmine_test")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
+
+jasmine_test(
+    name = "test",
+    args = ["**/*.test.js"],
+    data = ["fixed_args.test.js"],
+    fixed_args = ["--random=true"],
+    node_modules = "//:node_modules",
+)
+
+# assert that the launcher script contains the fixed arg --random=true
+assert_contains(
+    name = "fixed_args_test",
+    actual = ":test",
+    expected = "--random=true",
+)

--- a/jasmine/tests/fixed_args/fixed_args.test.js
+++ b/jasmine/tests/fixed_args/fixed_args.test.js
@@ -1,0 +1,5 @@
+describe("a test", () => {
+  it("2+2==4", () => {
+    expect(2 + 2).toBe(4);
+  });
+});


### PR DESCRIPTION
rules_js v1.27.0 adds a new fixed_args feature to js_binary & js_test that can be trivially added to jest_test.

---

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- New test cases added
