### PR TITLE
chore: update buildifier targets used by Aspect Workflows

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,10 +16,16 @@ gazelle(
 )
 
 buildifier(
+    name = "buildifier",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+    tags = ["manual"],  # tag as manual so windows ci does not build it by default
+)
+
+buildifier(
     name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-    ],
+    exclude_patterns = ["./.git/*"],
     lint_mode = "warn",
     mode = "diff",
     tags = ["manual"],  # tag as manual so windows ci does not build it by default


### PR DESCRIPTION
Aspect Workflows currently expects a `//:buildifier.check` target for checking and a `//:buildifier` target that is the suggested target to run when the buildifier check is red
