### PR TITLE
chore: run Aspect Workflows setup step on small instances

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -2,8 +2,10 @@
 ---
 tasks:
   format:
+    queue: aspect-small
     soft_fail: false
   buildifier:
+    queue: aspect-small
   test:
     bazel:
       # Generate and save the execution log to artifacts

--- a/.aspect/workflows/terraform/workflows.tf
+++ b/.aspect/workflows/terraform/workflows.tf
@@ -55,6 +55,14 @@ module "aspect_workflows" {
       image_id        = data.google_compute_image.runner_image.id
       use_preemptible = true
     }
+    small = {
+      # Aspect Workflows requires machine types that have local SSD drives. See
+      # https://cloud.google.com/compute/docs/machine-resource#machine_type_comparison for full list
+      # of machine types availble on GCP.
+      machine_type    = "n1-standard-1"
+      image_id        = data.google_compute_image.runner_image.id
+      use_preemptible = true
+    }
   }
 
   # GitHub Actions runner group definitions
@@ -71,9 +79,22 @@ module "aspect_workflows" {
       min_runners               = 0
       queue                     = "aspect-default"
       resource_type             = "default"
-      scale_out_factor          = 2
       scaling_polling_frequency = 1 # check for queued jobs every 60s
       warming                   = true
+    }
+    small = {
+      agent_idle_timeout_min = 1
+      gh_repo                = "aspect-build/rules_jasmine"
+      # Determine the workflow ID with:
+      # gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/aspect-build/rules_jasmine/actions/workflows
+      # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#list-repository-workflows
+      gha_workflow_ids          = ["67579950"] # Aspect Workflows
+      max_runners               = 5
+      min_runners               = 0
+      queue                     = "aspect-small"
+      resource_type             = "small"
+      scaling_polling_frequency = 1     # check for queued jobs every 60s
+      warming                   = false # don't warm for faster bootstrap; these runners won't be running large builds
     }
     # The warming runner group is used for the periodic warming job that creates
     # warming archives for use by other runner groups.

--- a/.github/workflows/aspect-workflows.yaml
+++ b/.github/workflows/aspect-workflows.yaml
@@ -14,3 +14,5 @@ jobs:
   aspect-workflows:
     name: Aspect Workflows
     uses: ./.github/workflows/.aspect-workflows-reusable.yaml
+    with:
+      queue: aspect-small


### PR DESCRIPTION
This pattern will work well for reducing compute costs for deployments. setup, buildifier & format steps will run on small instances and only the test setup will run on larger ones.

We could make this better by dropping the SSD requirements for Workflows so the setup step could run on an e2-small or e2-micro.