### PR TITLE
chore: upgrade to Bazel 7.0.2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,18 +2,11 @@
 # Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
-# Bazel picks up host-OS-specific config lines from bazelrc files. For example, if the host OS is
-# Linux and you run bazel build, Bazel picks up lines starting with build:linux. Supported OS
-# identifiers are `linux`, `macos`, `windows`, `freebsd`, and `openbsd`. Enabling this flag is
-# equivalent to using `--config=linux` on Linux, `--config=windows` on Windows, etc.
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
-common --enable_platform_specific_config
-
-# Required by rules_js
+# Runfiles still required for Windows in this repository despite not
+# being strictly necessary for rules_js support with
+# https://github.com/aspect-build/rules_js/pull/1428 landed.
+# TODO: fix broken targets on Windows and remove this flag
 build --enable_runfiles
-
-# Filter out tests depending on platform
-test:windows --test_tag_filters=-no-windows
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.4.0
+7.0.2
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/aspect-workflows-warming.yaml
+++ b/.github/workflows/aspect-workflows-warming.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Configure environment
         run: ${ASPECT_WORKFLOWS_BIN_DIR}/configure_workflows_env
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Agent health checks
         run: ${ASPECT_WORKFLOWS_BIN_DIR}/agent_health_check
       - name: Create warming archive

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,16 +1,19 @@
-# This file contains Bazel settings to apply on CI only.
-# It is referenced with a --bazelrc option in the call to bazel in ci.yaml
+# Directories caches by GitHub actions
+common --disk_cache=~/.cache/bazel-disk-cache
+common --repository_cache=~/.cache/bazel-repository-cache
+
+# Bazel version specific settings
+common:bazel6 --build_tag_filters=-skip-on-bazel6
+common:bazel6 --test_tag_filters=-skip-on-bazel6
+common:bazel7 --build_tag_filters=-skip-on-bazel7
+common:bazel7 --test_tag_filters=-skip-on-bazel7
 
 # Debug where options came from
 build --announce_rc
-# This directory is configured in GitHub actions to be persisted between runs.
-build --disk_cache=~/.cache/bazel
-build --repository_cache=~/.cache/bazel-repo
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME
-
 # Required by rules_js
 build --enable_runfiles

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,102 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Prepares dynamic test matrix values
+  matrix-prep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: bazel-version
+        name: Prepare 'bazel-version' matrix axis
+        run: |
+          v=$(head -n 1 .bazelversion)
+          m=${v::1}
+          a=(
+            "major:$m, version:\"$v\""
+            "major:6, version:\"6.5.0\""
+          )
+          printf -v j '{%s},' "${a[@]}"
+          echo "res=[${j%,}]" | tee -a $GITHUB_OUTPUT
+      - id: os
+        name: Prepare 'os' matrix axis
+        # Only run MacOS and Windows on main branch (not PRs) to minimize minutes (billed at 10X and 2X respectively)
+        # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+        run: |
+          a=( ubuntu )
+          if [[ "${{ github.ref_name }}" == "main" ]] || [[ "${{ github.head_ref }}" == *"macos"* ]]; then
+            a+=( macos )
+          fi
+          if [[ "${{ github.ref_name }}" == "main" ]] || [[ "${{ github.head_ref }}" == *"windows"* ]]; then
+            a+=( windows )
+          fi
+          printf -v j '"%s",' "${a[@]}"
+          echo "res=[${j%,}]" | tee -a $GITHUB_OUTPUT
+    outputs:
+      bazel-version: ${{ steps.bazel-version.outputs.res }}
+      os: ${{ steps.os.outputs.res }}
+
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
-    with:
-      folders: '[".", "e2e/jasmine_test", "e2e/smoke"]'
+    runs-on: ${{ matrix.os }}-latest
+    needs:
+      - matrix-prep
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel-version: ${{ fromJSON(needs.matrix-prep.outputs.bazel-version) }}
+        bzlmod: [1, 0]
+        os: ${{ fromJSON(needs.matrix-prep.outputs.os) }}
+        folder:
+          - '.'
+          - 'e2e/jasmine_test'
+          - 'e2e/smoke'
+        exclude:
+          # Don't test MacOS and Windows against secondary bazel version to minimize minutes (billed at 10X and 2X respectively)
+          # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+          - os: macos
+            bazel-version:
+              major: 6
+          - os: windows
+            bazel-version:
+              major: 6
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mount bazel caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/bazel-disk-cache
+            ~/.cache/bazel-repository-cache
+            ~/.cache/xdg-cache
+          key: bazel-cache-${{ matrix.bazelversion.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: bazel-cache-${{ matrix.bazelversion.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-
+
+      - name: Configure Bazel version
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        run: |
+          # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
+          # still bootstraps Aspect CLI from configuration in .bazeliskrc. Aspect CLI will
+          # then use .bazelversion to determine which Bazel version to use.
+          echo "${{ matrix.bazel-version.version }}" > .bazelversion
+
+      # TODO: remove this block once we have Aspect CLI Windows releases
+      - name: Don't use Aspect CLI on Windows
+        if: matrix.os == 'windows'
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        run: rm -f .bazeliskrc
+
+      - name: bazel test //...
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        run: |
+          bazel \
+            --bazelrc=${GITHUB_WORKSPACE//\\/\/}/.github/workflows/ci.bazelrc \
+            test \
+            --config=bazel${{ matrix.bazel-version.major }} \
+            --enable_bzlmod=${{ matrix.bzlmod }} \
+            //...
+        env:
+          XDG_CACHE_HOME: ~/.cache/xdg-cache # bazelisk will download bazel to here

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ bazel-*
 .idea/
 .ijwb/
 node_modules
+
+# Don't commit lockfile for now as it is unstable. Do allow for it to be
+# created, however, since it gives a performance boost for local development.
+# https://github.com/bazelbuild/bazel/issues/19026
+# https://github.com/bazelbuild/bazel/issues/19621
+# https://github.com/bazelbuild/bazel/issues/19971
+# https://github.com/bazelbuild/bazel/issues/20272
+# https://github.com/bazelbuild/bazel/issues/20369
+MODULE.bazel.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ default_stages: [commit]
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 4.0.1.1
+    rev: 6.4.0
     hooks:
       - id: buildifier
       - id: buildifier-lint

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,11 +6,14 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
-bazel_dep(name = "aspect_rules_js", version = "1.29.2")
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "rules_nodejs", version = "5.8.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.40.2")
+bazel_dep(name = "aspect_rules_js", version = "1.37.1")
+bazel_dep(name = "bazel_features", version = "1.4.1")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.3")
 
-bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
+bazel_dep(name = "aspect_rules_lint", version = "0.11.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,31 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+############################################
+# Stardoc
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
+
+load("@io_bazel_stardoc//:deps.bzl", "stardoc_external_deps")
+
+stardoc_external_deps()
+
+load("@stardoc_maven//:defs.bzl", stardoc_pinned_maven_install = "pinned_maven_install")
+
+stardoc_pinned_maven_install()
 
 ############################################
 # Gazelle, for generating bzl_library targets
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -6,9 +6,15 @@ stardoc_with_diff_test(
     name = "jasmine_test",
     bzl_library_target = "//jasmine:defs",
     symbol_names = ["jasmine_test"],
+    tags = ["skip-on-bazel6"],
 )
 
-update_docs(name = "update")
+update_docs(
+    name = "update",
+    # Failure on Bazel 6.5.0 with bzlmod enabled with unknown root cause not worth investigating:
+    # "Stardoc documentation generation failed: File /home/runner/.cache/bazel/_bazel_runner/49ae4abee64f46f5e03b51e3020410d1/sandbox/linux-sandbox/168/execroot/_main/bazel-out/k8-opt-exec-2B5CBBC6/bin/docs/jasmine_test_stardoc.runfiles/_main/jasmine/private/jasmine_test.bzl imported '@aspect_rules_js//js:libs.bzl', yet /home/runner/.cache/bazel/_bazel_runner/49ae4abee64f46f5e03b51e3020410d1/sandbox/linux-sandbox/168/execroot/_main/bazel-out/k8-opt-exec-2B5CBBC6/bin/docs/jasmine_test_stardoc.runfiles/aspect_rules_js/js/libs.bzl was not found."
+    tags = ["skip-on-bazel6"],
+)
 
 # Demonstration delivery target for Aspect Workflows.
 # In the future this could be wired up to push to a demonstration S3 bucket.

--- a/docs/jasmine_test.md
+++ b/docs/jasmine_test.md
@@ -18,12 +18,12 @@ Runs jasmine under `bazel test`
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="jasmine_test-name"></a>name |  A unique name for this target.   |  none |
-| <a id="jasmine_test-node_modules"></a>node_modules |  Label pointing to the linked node_modules target where jasmine is linked, e.g. <code>//:node_modules</code>.<br><br><code>jasmine</code> must be linked into the node_modules supplied. <code>jasmine-reporters</code> is also required by default when jasmine_reporters is True <code>jasmine-core</code> is required when using sharding.   |  none |
-| <a id="jasmine_test-jasmine_reporters"></a>jasmine_reporters |  Whether <code>jasmine-reporters</code> is present in the supplied node_modules tree.<br><br>When enabled, adds a custom reporter to output junit XML to the path where Bazel expects to find it.   |  <code>True</code> |
-| <a id="jasmine_test-config"></a>config |  jasmine config file. See: https://jasmine.github.io/setup/nodejs.html#configuration   |  <code>None</code> |
-| <a id="jasmine_test-timeout"></a>timeout |  standard attribute for tests. Defaults to "short" if both timeout and size are unspecified.   |  <code>None</code> |
-| <a id="jasmine_test-size"></a>size |  standard attribute for tests   |  <code>None</code> |
-| <a id="jasmine_test-data"></a>data |  Runtime dependencies that Jasmine should be able to read.<br><br>This should include all test files, configuration files & files under test.   |  <code>[]</code> |
-| <a id="jasmine_test-kwargs"></a>kwargs |  Additional named parameters from <code>js_test</code>. See [js_test docs](https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md#js_test)   |  none |
+| <a id="jasmine_test-node_modules"></a>node_modules |  Label pointing to the linked node_modules target where jasmine is linked, e.g. `//:node_modules`.<br><br>`jasmine` must be linked into the node_modules supplied. `jasmine-reporters` is also required by default when jasmine_reporters is True `jasmine-core` is required when using sharding.   |  none |
+| <a id="jasmine_test-jasmine_reporters"></a>jasmine_reporters |  Whether `jasmine-reporters` is present in the supplied node_modules tree.<br><br>When enabled, adds a custom reporter to output junit XML to the path where Bazel expects to find it.   |  `True` |
+| <a id="jasmine_test-config"></a>config |  jasmine config file. See: https://jasmine.github.io/setup/nodejs.html#configuration   |  `None` |
+| <a id="jasmine_test-timeout"></a>timeout |  standard attribute for tests. Defaults to "short" if both timeout and size are unspecified.   |  `None` |
+| <a id="jasmine_test-size"></a>size |  standard attribute for tests   |  `None` |
+| <a id="jasmine_test-data"></a>data |  Runtime dependencies that Jasmine should be able to read.<br><br>This should include all test files, configuration files & files under test.   |  `[]` |
+| <a id="jasmine_test-kwargs"></a>kwargs |  Additional named parameters from `js_test`. See [js_test docs](https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md#js_test)   |  none |
 
 

--- a/e2e/jasmine_test/.bazelversion
+++ b/e2e/jasmine_test/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/smoke/.bazelversion
+++ b/e2e/smoke/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -5,7 +5,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "aspect_rules_js", version = "1.29.2")
+bazel_dep(name = "aspect_rules_js", version = "1.37.1")
 
 bazel_dep(name = "aspect_rules_jasmine", version = "0.0.0", dev_dependency = True)
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -13,14 +13,14 @@ def rules_jasmine_internal_deps():
     "Fetch deps needed for local development"
     http_archive(
         name = "io_bazel_rules_go",
-        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip"],
+        sha256 = "6734a719993b1ba4ebe9806e853864395a8d3968ad27f9dd759c196b3eb3abe8",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
     )
 
     http_archive(
         name = "bazel_gazelle",
-        sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz"],
+        sha256 = "32938bda16e6700063035479063d9d24c60eda8d79fd4739563f50d331cb3209",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
     )
 
     http_archive(
@@ -31,22 +31,22 @@ def rules_jasmine_internal_deps():
 
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
-        urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
+        sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
+        urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
     )
 
     http_archive(
         name = "buildifier_prebuilt",
-        sha256 = "72b5bb0853aac597cce6482ee6c62513318e7f2c0050bc7c319d75d03d8a3875",
-        strip_prefix = "buildifier-prebuilt-6.3.3",
-        urls = ["https://github.com/keith/buildifier-prebuilt/archive/6.3.3.tar.gz"],
+        sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
+        strip_prefix = "buildifier-prebuilt-6.4.0",
+        urls = ["http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz"],
     )
 
     http_archive(
         name = "aspect_rules_lint",
-        sha256 = "604666ec7ffd4f5f2636001ae892a0fbc29c77401bb33dd10601504e3ba6e9a7",
-        strip_prefix = "rules_lint-0.6.1",
-        url = "https://github.com/aspect-build/rules_lint/releases/download/v0.6.1/rules_lint-v0.6.1.tar.gz",
+        sha256 = "98bed74aff6498ea9b58ff36db27a952c7a1b53764171c5d0d29ef0c61ffc4fb",
+        strip_prefix = "rules_lint-0.11.0",
+        url = "https://github.com/aspect-build/rules_lint/releases/download/v0.11.0/rules_lint-v0.11.0.tar.gz",
     )
 
     aspect_workflows_github_actions_deps()

--- a/jasmine/defs.bzl
+++ b/jasmine/defs.bzl
@@ -69,11 +69,11 @@ def jasmine_test(
         name = name,
         config = config,
         enable_runfiles = select({
-            "@aspect_rules_js//js/private:enable_runfiles": True,
+            "@aspect_rules_js//js:enable_runfiles": True,
             "//conditions:default": False,
         }),
         unresolved_symlinks_enabled = select({
-            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "@aspect_rules_js//js:allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         entry_point = entry_point,

--- a/jasmine/dependencies.bzl
+++ b/jasmine/dependencies.bzl
@@ -6,29 +6,37 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 
 load("//jasmine/private:maybe.bzl", http_archive = "maybe_http_archive")
 
+# buildifier: disable=function-docstring
 def rules_jasmine_dependencies():
     http_archive(
         name = "bazel_skylib",
-        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
+        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
     )
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
-        strip_prefix = "bazel-lib-1.32.1",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
+        sha256 = "04feedcd06f71d0497a81fdd3220140a373ff9d2bff94620fbd50b774f96d8e0",
+        strip_prefix = "bazel-lib-1.40.2",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
-        strip_prefix = "rules_js-1.29.2",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
+        sha256 = "630a71aba66c4023a5b16ab3efafaeed8b1a2865ccd168a34611eb73876b3fc4",
+        strip_prefix = "rules_js-1.37.1",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.37.1/rules_js-v1.37.1.tar.gz",
     )
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
+        sha256 = "8fc8e300cb67b89ceebd5b8ba6896ff273c84f6099fc88d23f24e7102319d8fd",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.4/rules_nodejs-core-5.8.4.tar.gz"],
+    )
+
+    http_archive(
+        name = "bazel_features",
+        sha256 = "0f23d75c7623d6dba1fd30513a94860447de87c8824570521fcc966eda3151c2",
+        strip_prefix = "bazel_features-1.4.1",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz",
     )

--- a/jasmine/tests/fixed_args/BUILD.bazel
+++ b/jasmine/tests/fixed_args/BUILD.bazel
@@ -14,7 +14,10 @@ assert_contains(
     name = "fixed_args_bash_launcher_test",
     actual = ":test",
     expected = "--random=true",
-    # this test asserts the contents of the bash launcher so is disabled on Windows
-    # since on Windows the default output of `:test` is the `.bat` wrapper
-    tags = ["no-windows"],
+    target_compatible_with = select({
+        # this test asserts the contents of the bash launcher so is disabled on Windows
+        # since on Windows the default output of `:test` is the `.bat` wrapper
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -7,6 +7,11 @@ load("@aspect_rules_lint//format:defs.bzl", "multi_formatter_binary")
 
 package(default_visibility = ["//:__subpackages__"])
 
+sh_binary(
+    name = "noop",
+    srcs = ["noop.sh"],
+)
+
 alias(
     name = "shfmt",
     actual = select({
@@ -14,6 +19,7 @@ alias(
         "@bazel_tools//src/conditions:darwin_x86_64": "@shfmt_darwin_x86_64//file:shfmt",
         "@bazel_tools//src/conditions:linux_aarch64": "@shfmt_linux_aarch64//file:shfmt",
         "@bazel_tools//src/conditions:linux_x86_64": "@shfmt_linux_x86_64//file:shfmt",
+        "//conditions:default": ":noop",
     }),
 )
 
@@ -23,12 +29,12 @@ alias(
         "@bazel_tools//src/conditions:darwin_arm64": "@terraform_macos_aarch64//:terraform",
         "@bazel_tools//src/conditions:darwin_x86_64": "@terraform_macos_x86_64//:terraform",
         "@bazel_tools//src/conditions:linux": "@terraform_linux_x86_64//:terraform",
+        "//conditions:default": ":noop",
     }),
 )
 
 multi_formatter_binary(
     name = "format",
-    go = "@go_sdk//:bin/gofmt",
     sh = ":shfmt",
     starlark = "@buildifier_prebuilt//:buildifier",
     terraform = ":terraform",

--- a/tools/noop.sh
+++ b/tools/noop.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "not implemented".
+exit 1


### PR DESCRIPTION
GHA CI matrix updated to new style which is rolled out already to rules_js and rules_esbuild. CI will test against Bazel 7.0.2 and 6.5.0.

Deps upgraded here in this PR were required to work with Bazel 7 and/or the expanded CI coverage for Windows.