### PR TITLE
chore: remove Go

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,19 +1,8 @@
-load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
-
-gazelle_binary(
-    name = "gazelle_bin",
-    languages = ["@bazel_skylib_gazelle_plugin//bzl"],
-)
-
-gazelle(
-    name = "gazelle",
-    gazelle = "gazelle_bin",
-)
 
 buildifier(
     name = "buildifier",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Otherwise later tooling on CI may yell at you about formatting/linting violation
 
 Some targets are generated from sources.
 Currently this is just the `bzl_library` targets.
-Run `bazel run //:gazelle` to keep them up-to-date.
+Run `aspect configure` to keep them up-to-date.
 
 ## Using this as a development dependency of other rules
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,4 @@ bazel_dep(name = "aspect_rules_js", version = "1.29.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 
-bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,18 +39,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-############################################
-# Gazelle, for generating bzl_library targets
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.19.3")
-
-gazelle_dependencies()
-
 # Buildifier
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -12,24 +12,6 @@ load("//jasmine/private:maybe.bzl", http_archive = "maybe_http_archive")
 def rules_jasmine_internal_deps():
     "Fetch deps needed for local development"
     http_archive(
-        name = "io_bazel_rules_go",
-        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip"],
-    )
-
-    http_archive(
-        name = "bazel_gazelle",
-        sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz"],
-    )
-
-    http_archive(
-        name = "bazel_skylib_gazelle_plugin",
-        sha256 = "0a466b61f331585f06ecdbbf2480b9edf70e067a53f261e0596acd573a7d2dc3",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-gazelle-plugin-1.4.1.tar.gz"],
-    )
-
-    http_archive(
         name = "io_bazel_stardoc",
         sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
         urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -28,7 +28,6 @@ alias(
 
 multi_formatter_binary(
     name = "format",
-    go = "@go_sdk//:bin/gofmt",
     sh = ":shfmt",
     starlark = "@buildifier_prebuilt//:buildifier",
     terraform = ":terraform",


### PR DESCRIPTION
We don't have any Go sources in rules_jasmine so there's no reason we should install a Go toolchain or worry about upgrading it. 'aspect configure' provides the auto-generation for bzl_library targets so we don't need Gazelle either.
