### PR TITLE
chore: fix GHA concurrency check to not apply to main branch

### DIFF
--- a/.github/workflows/aspect-workflows.yaml
+++ b/.github/workflows/aspect-workflows.yaml
@@ -10,6 +10,11 @@ on:
   # Allow this to be triggered manually via the GitHub UI Actions tab
   workflow_dispatch:
 
+concurrency:
+  # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
+  group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
 jobs:
   aspect-workflows:
     name: Aspect Workflows

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Cancel previous actions from same PR or branch except 'main' branch (https://stackoverflow.com/a/72408109)
+  group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   # Prepares dynamic test matrix values
@@ -62,9 +62,9 @@ jobs:
         bzlmod: [1, 0]
         os: ${{ fromJSON(needs.matrix-prep.outputs.os) }}
         folder:
-          - '.'
-          - 'e2e/jasmine_test'
-          - 'e2e/smoke'
+          - "."
+          - "e2e/jasmine_test"
+          - "e2e/smoke"
         exclude:
           # Don't test MacOS and Windows against secondary bazel version to minimize minutes (billed at 10X and 2X respectively)
           # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes


### PR DESCRIPTION
We shouldn't cancel concurrent builds on main.

Also, when cancelling, improves the message:
```
[test (7, 7.0.2, 1, ubuntu, e2e/jasmine_test)](https://github.com/aspect-build/rules_jasmine/actions/runs/8099265207/job/22134619410)
Canceling since a higher priority waiting request for 'concurrency-group::CI::pr-129' exists
```
https://github.com/aspect-build/rules_jasmine/actions/runs/8099265207