### PR TITLE
chore: make e2e/jasmine_test/MODULE.bazel a real file

### DIFF
--- a/e2e/jasmine_test/MODULE.bazel
+++ b/e2e/jasmine_test/MODULE.bazel
@@ -1,1 +1,16 @@
-../smoke/MODULE.bazel
+bazel_dep(name = "aspect_rules_jasmine", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "aspect_rules_jasmine",
+    path = "../..",
+)
+
+bazel_dep(name = "aspect_rules_js", version = "1.37.1", dev_dependency = True)
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
+npm.npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "@aspect_rules_jasmine//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")

--- a/e2e/jasmine_test/WORKSPACE.bzlmod
+++ b/e2e/jasmine_test/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Marker file that this is the root of a Bazel workspace.
+# This file replaces WORKSPACE.bazel under --enable_bzlmod.


### PR DESCRIPTION
Sharing a MODULE.bazel between e2e tests via a symlink is a bad pattern