### PR TITLE
ci: unpin SLSA reusable workflows from commit SHAs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,11 @@ on:
                 type: string
 jobs:
     publish:
-        uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@0a23c53c2baffdaf2ce8dd23c2c0e45eb3b79093 # v1.2.0
+        # SLSA trusted-builder reusable workflows MUST be referenced by a semantic
+        # version tag, not a commit SHA: slsa-verifier reads the builder ref from the
+        # provenance and rejects a bare SHA ("unexpected ref type"), which breaks the
+        # source.json attestation that BCR's presubmit verifies. Do not SHA-pin this.
+        uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
         with:
             draft: false
             tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,11 @@ permissions:
     contents: write
 jobs:
     release:
-        uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@e5ab8fc4c23cb13783fad499e8bd865fd9f6d669 # v7.6.0
+        # SLSA trusted-builder reusable workflows MUST be referenced by a semantic
+        # version tag, not a commit SHA: slsa-verifier reads the builder ref from the
+        # provenance and rejects a bare SHA ("unexpected ref type"), which breaks the
+        # release-artifact attestations that BCR's presubmit verifies. Do not SHA-pin.
+        uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.6.0
         with:
             release_files: rules_jasmine-*.tar.gz
             prerelease: false


### PR DESCRIPTION
slsa-verifier reads the trusted-builder ref from the provenance and
rejects a bare commit SHA ("unexpected ref type"), which breaks the
attestations that BCR's presubmit verifies. Pin to the semantic
version tag instead:

  publish-to-bcr/.github/workflows/publish.yaml  → @v1.2.0
  bazel-contrib/.github .../release_ruleset.yaml → @v7.6.0

Also adds a comment at each call site explaining why these must not
be SHA-pinned.
