### PR TITLE
chore(ci): update BCR fork location after move to aspect-forks org

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
             draft: false
             tag_name: ${{ inputs.tag_name }}
             # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
-            registry_fork: aspect-build/bazel-central-registry
+            registry_fork: aspect-forks/bazel-central-registry
         permissions:
             attestations: write
             contents: write


### PR DESCRIPTION
The `bazel-central-registry` fork moved from `aspect-build` to `aspect-forks`. Pushes to the old location still succeed via git's redirect handling, but the GitHub API does not follow repo redirects when resolving the PR `head` ref, so publish-to-bcr fails to open the BCR pull request with `422 Validation Failed: head invalid`.

This already broke the rules_js v3.2.0 release publish: https://github.com/aspect-build/rules_js/actions/runs/26905308688/job/79370430005 — every repo pointing `registry_fork` at the old location will hit the same failure on its next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)